### PR TITLE
kv_hash to return result for range checks instead of panicking and generalize hasher used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ version = "0.5.0"
 features = ["disable_initial_exec_tls"]
 optional = true
 
+[dependencies.digest]
+version = "0.9"
+
 [features]
 default = ["full", "verify"]
 full = ["rand",

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -11,7 +11,8 @@ fn insert_1m_10k_seq_memonly(b: &mut Bencher) {
     let initial_size = 1_000_000;
     let batch_size = 10_000;
 
-    let mut tree = Owner::new(make_tree_seq(initial_size));
+    let mut tree =
+        Owner::new(make_tree_seq(initial_size).expect("error constructing tree sequence"));
 
     let mut i = initial_size / batch_size;
     b.iter(|| {
@@ -41,7 +42,8 @@ fn update_1m_10k_seq_memonly(b: &mut Bencher) {
     let initial_size = 1_000_000;
     let batch_size = 10_000;
 
-    let mut tree = Owner::new(make_tree_seq(initial_size));
+    let mut tree =
+        Owner::new(make_tree_seq(initial_size).expect("error constructing tree sequence"));
 
     let mut i = 0;
     b.iter(|| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     HashMismatch([u8; 32], [u8; 32]),
     #[error("Index OoB Error: {0}")]
     IndexOutOfBounds(String),
+    #[error("Integer conversion error: {0}")]
+    IntegerConversionError(#[from] std::num::TryFromIntError),
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error("Tried to delete non-existent key {0:?}")]

--- a/src/merk/chunks.rs
+++ b/src/merk/chunks.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_and_verify_chunks() {
+    fn generate_and_verify_chunks() -> Result<()> {
         let mut merk = TempMerk::new().unwrap();
         let batch = make_batch_seq(1..10_000);
         merk.apply(batch.as_slice()).unwrap();
@@ -194,14 +194,15 @@ mod tests {
         let ops = Decoder::new(chunk.as_slice());
         let (trunk, height) = verify_trunk(ops).unwrap();
         assert_eq!(height, 14);
-        assert_eq!(trunk.hash(), merk.root_hash());
+        assert_eq!(trunk.hash()?, merk.root_hash());
 
         assert_eq!(trunk.layer(7).count(), 128);
 
         for (chunk, node) in chunks.zip(trunk.layer(height / 2)) {
             let ops = Decoder::new(chunk.as_slice());
-            verify_leaf(ops, node.hash()).unwrap();
+            verify_leaf(ops, node.hash()?).unwrap();
         }
+        Ok(())
     }
 
     #[test]

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -60,6 +60,26 @@ impl<T> Owner<T> {
         return_value
     }
 
+    /// Takes temporary ownership of the contained value by passing it to `f`.
+    /// The function must return a value of the same type (the same value, or a
+    /// new value to take its place).
+    ///
+    /// Like `own`, but with a fallible operation.
+    ///
+    /// # Example
+    /// ```
+    /// # use merk::owner::Owner;
+    /// # use std::convert::TryFrom;
+    /// let mut owner = Owner::new(123);
+    /// let converted = owner.own_fallible(|n| u32::try_from(n));
+    /// ```
+    pub fn own_fallible<E, F: FnOnce(T) -> Result<T, E>>(&mut self, f: F) -> Result<(), E> {
+        let old_value = unwrap(self.inner.take());
+        let new_value = f(old_value)?;
+        self.inner = Some(new_value);
+        Ok(())
+    }
+
     /// Sheds the `Owner` container and returns the value it contained.
     pub fn into_inner(mut self) -> T {
         unwrap(self.inner.take())

--- a/src/proofs/query/mod.rs
+++ b/src/proofs/query/mod.rs
@@ -343,8 +343,8 @@ pub fn verify(bytes: &[u8], expected_hash: Hash) -> Result<Map> {
 
     let root = execute(ops, true, |node| map_builder.insert(node))?;
 
-    if root.hash() != expected_hash {
-        return Err(Error::HashMismatch(expected_hash, root.hash()));
+    if root.hash()? != expected_hash {
+        return Err(Error::HashMismatch(expected_hash, root.hash()?));
     }
 
     Ok(map_builder.build())
@@ -459,8 +459,8 @@ pub fn verify_query(
         }
     }
 
-    if root.hash() != expected_hash {
-        return Err(Error::HashMismatch(expected_hash, root.hash()));
+    if root.hash()? != expected_hash {
+        return Err(Error::HashMismatch(expected_hash, root.hash()?));
     }
 
     Ok(output)
@@ -475,16 +475,16 @@ mod test {
     use crate::test_utils::make_tree_seq;
     use crate::tree::{NoopCommit, PanicSource, RefWalker, Tree};
 
-    fn make_3_node_tree() -> Tree {
-        let mut tree = Tree::new(vec![5], vec![5])
-            .attach(true, Some(Tree::new(vec![3], vec![3])))
-            .attach(false, Some(Tree::new(vec![7], vec![7])));
+    fn make_3_node_tree() -> Result<Tree> {
+        let mut tree = Tree::new(vec![5], vec![5])?
+            .attach(true, Some(Tree::new(vec![3], vec![3])?))
+            .attach(false, Some(Tree::new(vec![7], vec![7])?));
         tree.commit(&mut NoopCommit {}).expect("commit failed");
-        tree
+        Ok(tree)
     }
 
-    fn verify_keys_test(keys: Vec<Vec<u8>>, expected_result: Vec<Option<Vec<u8>>>) {
-        let mut tree = make_3_node_tree();
+    fn verify_keys_test(keys: Vec<Vec<u8>>, expected_result: Vec<Option<Vec<u8>>>) -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let (proof, _) = walker
@@ -519,59 +519,61 @@ mod test {
         for (key, expected_value) in keys.iter().zip(expected_result.iter()) {
             assert_eq!(values.get(key), expected_value.as_ref());
         }
+
+        Ok(())
     }
 
     #[test]
-    fn root_verify() {
-        verify_keys_test(vec![vec![5]], vec![Some(vec![5])]);
+    fn root_verify() -> Result<()> {
+        verify_keys_test(vec![vec![5]], vec![Some(vec![5])])
     }
 
     #[test]
-    fn single_verify() {
-        verify_keys_test(vec![vec![3]], vec![Some(vec![3])]);
+    fn single_verify() -> Result<()> {
+        verify_keys_test(vec![vec![3]], vec![Some(vec![3])])
     }
 
     #[test]
-    fn double_verify() {
-        verify_keys_test(vec![vec![3], vec![5]], vec![Some(vec![3]), Some(vec![5])]);
+    fn double_verify() -> Result<()> {
+        verify_keys_test(vec![vec![3], vec![5]], vec![Some(vec![3]), Some(vec![5])])
     }
 
     #[test]
-    fn double_verify_2() {
-        verify_keys_test(vec![vec![3], vec![7]], vec![Some(vec![3]), Some(vec![7])]);
+    fn double_verify_2() -> Result<()> {
+        verify_keys_test(vec![vec![3], vec![7]], vec![Some(vec![3]), Some(vec![7])])
     }
 
     #[test]
-    fn triple_verify() {
+    fn triple_verify() -> Result<()> {
         verify_keys_test(
             vec![vec![3], vec![5], vec![7]],
             vec![Some(vec![3]), Some(vec![5]), Some(vec![7])],
-        );
+        )
     }
 
     #[test]
-    fn left_edge_absence_verify() {
-        verify_keys_test(vec![vec![2]], vec![None]);
+    fn left_edge_absence_verify() -> Result<()> {
+        verify_keys_test(vec![vec![2]], vec![None])
     }
 
     #[test]
-    fn right_edge_absence_verify() {
-        verify_keys_test(vec![vec![8]], vec![None]);
+    fn right_edge_absence_verify() -> Result<()> {
+        verify_keys_test(vec![vec![8]], vec![None])
     }
 
     #[test]
-    fn inner_absence_verify() {
-        verify_keys_test(vec![vec![6]], vec![None]);
+    fn inner_absence_verify() -> Result<()> {
+        verify_keys_test(vec![vec![6]], vec![None])
     }
 
     #[test]
-    fn absent_and_present_verify() {
-        verify_keys_test(vec![vec![5], vec![6]], vec![Some(vec![5]), None]);
+    fn absent_and_present_verify() -> Result<()> {
+        verify_keys_test(vec![vec![5], vec![6]], vec![Some(vec![5]), None])
     }
 
     #[test]
-    fn empty_proof() {
-        let mut tree = make_3_node_tree();
+    fn empty_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let (proof, absence) = walker
@@ -609,11 +611,12 @@ mod test {
         encode_into(proof.iter(), &mut bytes);
         let res = verify_query(bytes.as_slice(), &Query::new(), tree.hash()).unwrap();
         assert!(res.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn root_proof() {
-        let mut tree = make_3_node_tree();
+    fn root_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![5])];
@@ -650,11 +653,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![(vec![5], vec![5])]);
+        Ok(())
     }
 
     #[test]
-    fn leaf_proof() {
-        let mut tree = make_3_node_tree();
+    fn leaf_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![3])];
@@ -691,11 +695,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![(vec![3], vec![3])]);
+        Ok(())
     }
 
     #[test]
-    fn double_leaf_proof() {
-        let mut tree = make_3_node_tree();
+    fn double_leaf_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![3]), QueryItem::Key(vec![7])];
@@ -726,11 +731,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![(vec![3], vec![3]), (vec![7], vec![7]),]);
+        Ok(())
     }
 
     #[test]
-    fn all_nodes_proof() {
-        let mut tree = make_3_node_tree();
+    fn all_nodes_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![
@@ -762,11 +768,12 @@ mod test {
             res,
             vec![(vec![3], vec![3]), (vec![5], vec![5]), (vec![7], vec![7]),]
         );
+        Ok(())
     }
 
     #[test]
-    fn global_edge_absence_proof() {
-        let mut tree = make_3_node_tree();
+    fn global_edge_absence_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![8])];
@@ -803,11 +810,12 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![]);
+        Ok(())
     }
 
     #[test]
-    fn absence_proof() {
-        let mut tree = make_3_node_tree();
+    fn absence_proof() -> Result<()> {
+        let mut tree = make_3_node_tree()?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Key(vec![6])];
@@ -838,21 +846,22 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![]);
+        Ok(())
     }
 
     #[test]
-    fn doc_proof() {
-        let mut tree = Tree::new(vec![5], vec![5])
+    fn doc_proof() -> Result<()> {
+        let mut tree = Tree::new(vec![5], vec![5])?
             .attach(
                 true,
                 Some(
-                    Tree::new(vec![2], vec![2])
-                        .attach(true, Some(Tree::new(vec![1], vec![1])))
+                    Tree::new(vec![2], vec![2])?
+                        .attach(true, Some(Tree::new(vec![1], vec![1])?))
                         .attach(
                             false,
                             Some(
-                                Tree::new(vec![4], vec![4])
-                                    .attach(true, Some(Tree::new(vec![3], vec![3]))),
+                                Tree::new(vec![4], vec![4])?
+                                    .attach(true, Some(Tree::new(vec![3], vec![3])?)),
                             ),
                         ),
                 ),
@@ -860,20 +869,20 @@ mod test {
             .attach(
                 false,
                 Some(
-                    Tree::new(vec![9], vec![9])
+                    Tree::new(vec![9], vec![9])?
                         .attach(
                             true,
                             Some(
-                                Tree::new(vec![7], vec![7])
-                                    .attach(true, Some(Tree::new(vec![6], vec![6])))
-                                    .attach(false, Some(Tree::new(vec![8], vec![8]))),
+                                Tree::new(vec![7], vec![7])?
+                                    .attach(true, Some(Tree::new(vec![6], vec![6])?))
+                                    .attach(false, Some(Tree::new(vec![8], vec![8])?)),
                             ),
                         )
                         .attach(
                             false,
                             Some(
-                                Tree::new(vec![11], vec![11])
-                                    .attach(true, Some(Tree::new(vec![10], vec![10]))),
+                                Tree::new(vec![11], vec![11])?
+                                    .attach(true, Some(Tree::new(vec![10], vec![10])?)),
                             ),
                         ),
                 ),
@@ -948,6 +957,7 @@ mod test {
                 (vec![4], vec![4]),
             ]
         );
+        Ok(())
     }
 
     #[test]
@@ -1016,8 +1026,8 @@ mod test {
     }
 
     #[test]
-    fn range_proof() {
-        let mut tree = make_tree_seq(10);
+    fn range_proof() -> Result<()> {
+        let mut tree = make_tree_seq(10)?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Range(
@@ -1100,11 +1110,12 @@ mod test {
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn range_proof_inclusive() {
-        let mut tree = make_tree_seq(10);
+    fn range_proof_inclusive() -> Result<()> {
+        let mut tree = make_tree_seq(10)?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::RangeInclusive(
@@ -1188,11 +1199,12 @@ mod test {
                 (vec![0, 0, 0, 0, 0, 0, 0, 7], vec![123; 60]),
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn range_proof_missing_upper_bound() {
-        let mut tree = make_tree_seq(10);
+    fn range_proof_missing_upper_bound() -> Result<()> {
+        let mut tree = make_tree_seq(10)?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![QueryItem::Range(
@@ -1275,11 +1287,12 @@ mod test {
                 (vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn range_proof_missing_lower_bound() {
-        let mut tree = make_tree_seq(10);
+    fn range_proof_missing_lower_bound() -> Result<()> {
+        let mut tree = make_tree_seq(10)?;
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
 
         let queryitems = vec![
@@ -1357,6 +1370,7 @@ mod test {
         }
         let res = verify_query(bytes.as_slice(), &query, tree.hash()).unwrap();
         assert_eq!(res, vec![(vec![0, 0, 0, 0, 0, 0, 0, 6], vec![123; 60]),]);
+        Ok(())
     }
 
     #[test]
@@ -1403,8 +1417,8 @@ mod test {
     }
 
     #[test]
-    fn verify_ops() {
-        let mut tree = Tree::new(vec![5], vec![5]);
+    fn verify_ops() -> Result<()> {
+        let mut tree = Tree::new(vec![5], vec![5])?;
         tree.commit(&mut NoopCommit {}).expect("commit failed");
 
         let root_hash = tree.hash();
@@ -1422,12 +1436,13 @@ mod test {
             map.get(vec![5].as_slice()).unwrap().unwrap(),
             vec![5].as_slice()
         );
+        Ok(())
     }
 
     #[test]
     #[should_panic(expected = "verify failed")]
     fn verify_ops_mismatched_hash() {
-        let mut tree = Tree::new(vec![5], vec![5]);
+        let mut tree = Tree::new(vec![5], vec![5]).expect("tree construction failed");
         tree.commit(&mut NoopCommit {}).expect("commit failed");
 
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
@@ -1445,7 +1460,7 @@ mod test {
     #[test]
     #[should_panic(expected = "verify failed")]
     fn verify_query_mismatched_hash() {
-        let mut tree = make_3_node_tree();
+        let mut tree = make_3_node_tree().expect("tree construction failed");
         let mut walker = RefWalker::new(&mut tree, PanicSource {});
         let keys = vec![vec![5], vec![7]];
         let (proof, _) = walker

--- a/src/proofs/tree.rs
+++ b/src/proofs/tree.rs
@@ -1,6 +1,7 @@
 use super::{Node, Op};
 use crate::error::{Error, Result};
 use crate::tree::{kv_hash, node_hash, Hash, NULL_HASH};
+use blake3::Hasher;
 
 /// Contains a tree's child node and its hash. The hash can always be assumed to
 /// be up-to-date.
@@ -35,24 +36,25 @@ impl From<Node> for Tree {
 impl PartialEq for Tree {
     /// Checks equality for the root hashes of the two trees.
     fn eq(&self, other: &Self) -> bool {
-        self.hash() == other.hash()
+        self.hash()
+            .and_then(|this_hash| other.hash().map(|other_hash| this_hash == other_hash))
+            .unwrap_or_default()
     }
 }
 
 impl Tree {
     /// Gets or computes the hash for this tree node.
-    pub fn hash(&self) -> Hash {
+    pub fn hash(&self) -> Result<Hash> {
         fn compute_hash(tree: &Tree, kv_hash: Hash) -> Hash {
-            node_hash(&kv_hash, &tree.child_hash(true), &tree.child_hash(false))
+            node_hash::<Hasher>(&kv_hash, &tree.child_hash(true), &tree.child_hash(false))
         }
 
         match &self.node {
-            Node::Hash(hash) => *hash,
-            Node::KVHash(kv_hash) => compute_hash(self, *kv_hash),
-            Node::KV(key, value) => {
-                let kv_hash = kv_hash(key.as_slice(), value.as_slice());
-                compute_hash(self, kv_hash)
-            }
+            Node::Hash(hash) => Ok(*hash),
+            Node::KVHash(kv_hash) => Ok(compute_hash(self, *kv_hash)),
+            Node::KV(key, value) => kv_hash::<Hasher>(key.as_slice(), value.as_slice())
+                .map(|kv_hash| compute_hash(self, kv_hash))
+                .map_err(Into::into),
         }
     }
 
@@ -120,7 +122,7 @@ impl Tree {
 
         self.height = self.height.max(child.height + 1);
 
-        let hash = child.hash();
+        let hash = child.hash()?;
         let tree = Box::new(child);
         *self.child_mut(left) = Some(Child { tree, hash });
 
@@ -137,8 +139,8 @@ impl Tree {
 
     /// Consumes the tree node, calculates its hash, and returns a `Node::Hash`
     /// variant.
-    fn into_hash(self) -> Tree {
-        Node::Hash(self.hash()).into()
+    fn try_into_hash(self) -> Result<Tree> {
+        self.hash().map(Node::Hash).map(Into::into)
     }
 
     #[cfg(feature = "full")]
@@ -249,12 +251,26 @@ where
         match op? {
             Op::Parent => {
                 let (mut parent, child) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(true, if collapse { child.into_hash() } else { child })?;
+                parent.attach(
+                    true,
+                    if collapse {
+                        child.try_into_hash()?
+                    } else {
+                        child
+                    },
+                )?;
                 stack.push(parent);
             }
             Op::Child => {
                 let (child, mut parent) = (try_pop(&mut stack)?, try_pop(&mut stack)?);
-                parent.attach(false, if collapse { child.into_hash() } else { child })?;
+                parent.attach(
+                    false,
+                    if collapse {
+                        child.try_into_hash()?
+                    } else {
+                        child
+                    },
+                )?;
                 stack.push(parent);
             }
             Op::Push(node) => {

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -124,7 +124,7 @@ pub fn make_tree_rand(node_count: u64, batch_size: u64, initial_seed: u64) -> Tr
     assert!((node_count % batch_size) == 0);
 
     let value = vec![123; 60];
-    let mut tree = Tree::new(vec![0; 20], value);
+    let mut tree = Tree::new(vec![0; 20], value).expect("Tree construction failed");
 
     let mut seed = initial_seed;
 
@@ -138,7 +138,7 @@ pub fn make_tree_rand(node_count: u64, batch_size: u64, initial_seed: u64) -> Tr
     tree
 }
 
-pub fn make_tree_seq(node_count: u64) -> Tree {
+pub fn make_tree_seq(node_count: u64) -> crate::error::Result<Tree> {
     let batch_size = if node_count >= 10_000 {
         assert!(node_count % 10_000 == 0);
         10_000
@@ -147,7 +147,7 @@ pub fn make_tree_seq(node_count: u64) -> Tree {
     };
 
     let value = vec![123; 60];
-    let mut tree = Tree::new(vec![0; 20], value);
+    let mut tree = Tree::new(vec![0; 20], value)?;
 
     let batch_count = node_count / batch_size;
     for i in 0..batch_count {
@@ -155,5 +155,5 @@ pub fn make_tree_seq(node_count: u64) -> Tree {
         tree = apply_memonly(tree, &batch);
     }
 
-    tree
+    Ok(tree)
 }

--- a/src/tree/encoding.rs
+++ b/src/tree/encoding.rs
@@ -40,6 +40,7 @@ impl Tree {
 mod tests {
     use super::super::Link;
     use super::*;
+    use crate::error::Result;
 
     #[test]
     fn encode_leaf_tree() {
@@ -64,7 +65,7 @@ mod tests {
             Some(Link::Modified {
                 pending_writes: 1,
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3]).unwrap(),
             }),
             None,
         );
@@ -72,7 +73,7 @@ mod tests {
     }
 
     #[test]
-    fn encode_loaded_tree() {
+    fn encode_loaded_tree() -> Result<()> {
         let tree = Tree::from_fields(
             vec![0],
             vec![1],
@@ -80,7 +81,7 @@ mod tests {
             Some(Link::Loaded {
                 hash: [66; 32],
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3])?,
             }),
             None,
         );
@@ -93,10 +94,11 @@ mod tests {
                 55, 55, 55, 55, 55, 55, 55, 55, 1
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn encode_uncommitted_tree() {
+    fn encode_uncommitted_tree() -> Result<()> {
         let tree = Tree::from_fields(
             vec![0],
             vec![1],
@@ -104,7 +106,7 @@ mod tests {
             Some(Link::Uncommitted {
                 hash: [66; 32],
                 child_heights: (123, 124),
-                tree: Tree::new(vec![2], vec![3]),
+                tree: Tree::new(vec![2], vec![3])?,
             }),
             None,
         );
@@ -117,6 +119,7 @@ mod tests {
                 55, 55, 55, 55, 55, 55, 55, 55, 1
             ]
         );
+        Ok(())
     }
 
     #[test]

--- a/src/tree/hash.rs
+++ b/src/tree/hash.rs
@@ -1,4 +1,7 @@
-use std::convert::TryFrom;
+use {
+    digest::Digest,
+    std::{convert::TryFrom, num::TryFromIntError},
+};
 
 /// The length of a `Hash` (in bytes).
 pub const HASH_LENGTH: usize = 32;
@@ -11,39 +14,37 @@ pub type Hash = [u8; HASH_LENGTH];
 
 /// Hashes a key/value pair.
 ///
-/// **NOTE:** This will panic if the key is longer than 255 bytes, or the value
+/// **NOTE:** This will error if the key is longer than 255 bytes, or the value
 /// is longer than 65,535 bytes.
-pub fn kv_hash(key: &[u8], value: &[u8]) -> Hash {
-    // TODO: result instead of panic
-    // TODO: make generic to allow other hashers
-    let mut hasher = blake3::Hasher::new();
-    // panics if key is longer than 255!
-    let key_length = u8::try_from(key.len()).expect("key must be less than 256 bytes");
-    hasher.update(&key_length.to_be_bytes());
-    hasher.update(key);
+pub fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError> {
+    let mut hasher = D::new();
+    u8::try_from(key.len())
+        .and_then(|key| u16::try_from(value.len()).map(|value| (key, value)))
+        .map(|(key_length, val_length)| {
+            hasher.update(key_length.to_be_bytes());
+            hasher.update(key);
 
-    // panics if value is longer than 65535!
-    let val_length = u16::try_from(value.len()).expect("value must be less than 65,536 bytes");
-    hasher.update(&val_length.to_be_bytes());
-    hasher.update(value);
+            hasher.update(val_length.to_be_bytes());
+            hasher.update(value);
 
-    let res = hasher.finalize();
-    let mut hash: Hash = Default::default();
-    hash.copy_from_slice(res.as_bytes());
-    hash
+            let res = hasher.finalize();
+            let mut hash: Hash = Default::default();
+            hash.copy_from_slice(res.as_slice());
+            hash
+        })
 }
 
 /// Hashes a node based on the hash of its key/value pair, the hash of its left
 /// child (if any), and the hash of its right child (if any).
-pub fn node_hash(kv: &Hash, left: &Hash, right: &Hash) -> Hash {
+pub fn node_hash<D: Digest>(kv: &Hash, left: &Hash, right: &Hash) -> Hash {
     // TODO: make generic to allow other hashers
-    let mut hasher = blake3::Hasher::new();
+    let mut hasher = D::new();
     hasher.update(kv);
     hasher.update(left);
     hasher.update(right);
 
     let res = hasher.finalize();
     let mut hash: Hash = Default::default();
-    hash.copy_from_slice(res.as_bytes());
+    hash.copy_from_slice(res.as_slice());
     hash
 }

--- a/src/tree/kv.rs
+++ b/src/tree/kv.rs
@@ -1,6 +1,10 @@
 use super::hash::{kv_hash, Hash, HASH_LENGTH, NULL_HASH};
+use blake3::Hasher;
 use ed::{Decode, Encode, Result};
-use std::io::{Read, Write};
+use std::{
+    io::{Read, Write},
+    num::TryFromIntError,
+};
 
 // TODO: maybe use something similar to Vec but without capacity field,
 //       (should save 16 bytes per entry). also, maybe a shorter length
@@ -17,10 +21,8 @@ pub struct KV {
 impl KV {
     /// Creates a new `KV` with the given key and value and computes its hash.
     #[inline]
-    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
-        // TODO: length checks?
-        let hash = kv_hash(key.as_slice(), value.as_slice());
-        KV { key, value, hash }
+    pub fn new(key: Vec<u8>, value: Vec<u8>) -> std::result::Result<Self, TryFromIntError> {
+        kv_hash::<Hasher>(key.as_slice(), value.as_slice()).map(|hash| KV { key, value, hash })
     }
 
     /// Creates a new `KV` with the given key, value, and hash. The hash is not
@@ -33,11 +35,10 @@ impl KV {
     /// Replaces the `KV`'s value with the given value, updates the hash, and
     /// returns the modified `KV`.
     #[inline]
-    pub fn with_value(mut self, value: Vec<u8>) -> Self {
-        // TODO: length check?
+    pub fn with_value(mut self, value: Vec<u8>) -> std::result::Result<Self, TryFromIntError> {
         self.value = value;
-        self.hash = kv_hash(self.key(), self.value());
-        self
+        self.hash = kv_hash::<Hasher>(self.key(), self.value())?;
+        Ok(self)
     }
 
     /// Returns the key as a slice.
@@ -110,20 +111,22 @@ mod test {
     use super::*;
 
     #[test]
-    fn new_kv() {
-        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6]);
+    fn new_kv() -> std::result::Result<(), TryFromIntError> {
+        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6])?;
 
         assert_eq!(kv.key(), &[1, 2, 3]);
         assert_eq!(kv.value(), &[4, 5, 6]);
         assert_ne!(kv.hash(), &super::super::hash::NULL_HASH);
+        Ok(())
     }
 
     #[test]
-    fn with_value() {
-        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6]).with_value(vec![7, 8, 9]);
+    fn with_value() -> std::result::Result<(), TryFromIntError> {
+        let kv = KV::new(vec![1, 2, 3], vec![4, 5, 6])?.with_value(vec![7, 8, 9])?;
 
         assert_eq!(kv.key(), &[1, 2, 3]);
         assert_eq!(kv.value(), &[7, 8, 9]);
         assert_ne!(kv.hash(), &super::super::hash::NULL_HASH);
+        Ok(())
     }
 }

--- a/src/tree/link.rs
+++ b/src/tree/link.rs
@@ -312,31 +312,33 @@ mod test {
     use super::*;
 
     #[test]
-    fn from_modified_tree() {
-        let tree = Tree::new(vec![0], vec![1]);
+    fn from_modified_tree() -> std::result::Result<(), &'static str> {
+        let tree = Tree::new(vec![0], vec![1]).map_err(|_| "tree construction failed")?;
         let link = Link::from_modified_tree(tree);
         assert!(link.is_modified());
         assert_eq!(link.height(), 1);
         assert_eq!(link.tree().expect("expected tree").key(), &[0]);
         if let Link::Modified { pending_writes, .. } = link {
             assert_eq!(pending_writes, 1);
+            Ok(())
         } else {
-            panic!("Expected Link::Modified");
+            Err("Expected Link::Modified")
         }
     }
 
     #[test]
-    fn maybe_from_modified_tree() {
+    fn maybe_from_modified_tree() -> std::result::Result<(), crate::error::Error> {
         let link = Link::maybe_from_modified_tree(None);
         assert!(link.is_none());
 
-        let tree = Tree::new(vec![0], vec![1]);
+        let tree = Tree::new(vec![0], vec![1])?;
         let link = Link::maybe_from_modified_tree(Some(tree));
         assert!(link.expect("expected link").is_modified());
+        Ok(())
     }
 
     #[test]
-    fn types() {
+    fn types() -> std::result::Result<(), crate::error::Error> {
         let hash = NULL_HASH;
         let child_heights = (0, 0);
         let pending_writes = 1;
@@ -351,17 +353,17 @@ mod test {
         let modified = Link::Modified {
             pending_writes,
             child_heights,
-            tree: tree(),
+            tree: tree()?,
         };
         let uncommitted = Link::Uncommitted {
             hash,
             child_heights,
-            tree: tree(),
+            tree: tree()?,
         };
         let loaded = Link::Loaded {
             hash,
             child_heights,
-            tree: tree(),
+            tree: tree()?,
         };
 
         assert!(reference.is_reference());
@@ -396,17 +398,21 @@ mod test {
         assert_eq!(loaded.hash(), &[0; 32]);
         assert_eq!(loaded.height(), 1);
         assert!(loaded.into_reference().is_reference());
+        Ok(())
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Cannot get hash from modified link")]
     fn modified_hash() {
-        Link::Modified {
-            pending_writes: 1,
-            child_heights: (1, 1),
-            tree: Tree::new(vec![0], vec![1]),
-        }
-        .hash();
+        Tree::new(vec![0], vec![1])
+            .map(|tree| Link::Modified {
+                pending_writes: 1,
+                child_heights: (1, 1),
+                tree,
+            })
+            .map(|link| link.hash().to_vec())
+            .map(|_| ())
+            .unwrap_or_default()
     }
 
     #[test]
@@ -415,7 +421,7 @@ mod test {
         Link::Modified {
             pending_writes: 1,
             child_heights: (1, 1),
-            tree: Tree::new(vec![0], vec![1]),
+            tree: Tree::new(vec![0], vec![1]).expect("tree construction failed"),
         }
         .into_reference();
     }
@@ -426,7 +432,7 @@ mod test {
         Link::Uncommitted {
             hash: [1; 32],
             child_heights: (1, 1),
-            tree: Tree::new(vec![0], vec![1]),
+            tree: Tree::new(vec![0], vec![1]).expect("tree construction failed"),
         }
         .into_reference();
     }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -47,14 +47,14 @@ impl Tree {
     /// Creates a new `Tree` with the given key and value, and no children.
     ///
     /// Hashes the key/value pair and initializes the `kv_hash` field.
-    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
-        Tree {
+    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Result<Self> {
+        KV::new(key, value).map_err(Into::into).map(|kv| Tree {
             inner: Box::new(TreeInner {
-                kv: KV::new(key, value),
+                kv,
                 left: None,
                 right: None,
             }),
-        }
+        })
     }
 
     /// Creates a `Tree` by supplying all the raw struct fields (mainly useful
@@ -155,7 +155,7 @@ impl Tree {
     /// Computes and returns the hash of the root node.
     #[inline]
     pub fn hash(&self) -> Hash {
-        node_hash(
+        node_hash::<blake3::Hasher>(
             self.inner.kv.hash(),
             self.child_hash(true),
             self.child_hash(false),
@@ -307,9 +307,9 @@ impl Tree {
     /// Replaces the root node's value with the given value and returns the
     /// modified `Tree`.
     #[inline]
-    pub fn with_value(mut self, value: Vec<u8>) -> Self {
-        self.inner.kv = self.inner.kv.with_value(value);
-        self
+    pub fn with_value(mut self, value: Vec<u8>) -> Result<Self> {
+        self.inner.kv = self.inner.kv.with_value(value)?;
+        Ok(self)
     }
 
     // TODO: add compute_hashes method
@@ -444,10 +444,11 @@ mod test {
     use super::commit::NoopCommit;
     use super::hash::NULL_HASH;
     use super::Tree;
+    use crate::error::Result;
 
     #[test]
-    fn build_tree() {
-        let tree = Tree::new(vec![1], vec![101]);
+    fn build_tree() -> Result<()> {
+        let tree = Tree::new(vec![1], vec![101])?;
         assert_eq!(tree.key(), &[1]);
         assert_eq!(tree.value(), &[101]);
         assert!(tree.child(true).is_none());
@@ -457,30 +458,38 @@ mod test {
         assert!(tree.child(true).is_none());
         assert!(tree.child(false).is_none());
 
-        let tree = tree.attach(true, Some(Tree::new(vec![2], vec![102])));
+        let tree = tree.attach(true, Some(Tree::new(vec![2], vec![102])?));
         assert_eq!(tree.key(), &[1]);
         assert_eq!(tree.child(true).unwrap().key(), &[2]);
         assert!(tree.child(false).is_none());
 
-        let tree = Tree::new(vec![3], vec![103]).attach(false, Some(tree));
+        let tree = Tree::new(vec![3], vec![103])?.attach(false, Some(tree));
         assert_eq!(tree.key(), &[3]);
         assert_eq!(tree.child(false).unwrap().key(), &[1]);
         assert!(tree.child(true).is_none());
+        Ok(())
     }
 
     #[should_panic]
     #[test]
     fn attach_existing() {
         Tree::new(vec![0], vec![1])
-            .attach(true, Some(Tree::new(vec![2], vec![3])))
-            .attach(true, Some(Tree::new(vec![4], vec![5])));
+            .expect("tree construction failed")
+            .attach(
+                true,
+                Some(Tree::new(vec![2], vec![3]).expect("tree construction failed")),
+            )
+            .attach(
+                true,
+                Some(Tree::new(vec![4], vec![5]).expect("tree construction failed")),
+            );
     }
 
     #[test]
-    fn modify() {
-        let tree = Tree::new(vec![0], vec![1])
-            .attach(true, Some(Tree::new(vec![2], vec![3])))
-            .attach(false, Some(Tree::new(vec![4], vec![5])));
+    fn modify() -> Result<()> {
+        let tree = Tree::new(vec![0], vec![1])?
+            .attach(true, Some(Tree::new(vec![2], vec![3])?))
+            .attach(false, Some(Tree::new(vec![4], vec![5])?));
 
         let tree = tree.walk(true, |left_opt| {
             assert_eq!(left_opt.as_ref().unwrap().key(), &[2]);
@@ -489,9 +498,10 @@ mod test {
         assert!(tree.child(true).is_none());
         assert!(tree.child(false).is_some());
 
+        let fixed_tree = Some(Tree::new(vec![2], vec![3])?);
         let tree = tree.walk(true, |left_opt| {
             assert!(left_opt.is_none());
-            Some(Tree::new(vec![2], vec![3]))
+            fixed_tree
         });
         assert_eq!(tree.link(true).unwrap().key(), &[2]);
 
@@ -501,11 +511,13 @@ mod test {
         });
         assert!(tree.child(true).is_some());
         assert!(tree.child(false).is_none());
+        Ok(())
     }
 
     #[test]
-    fn child_and_link() {
-        let mut tree = Tree::new(vec![0], vec![1]).attach(true, Some(Tree::new(vec![2], vec![3])));
+    fn child_and_link() -> Result<()> {
+        let mut tree =
+            Tree::new(vec![0], vec![1])?.attach(true, Some(Tree::new(vec![2], vec![3])?));
         assert!(tree.link(true).expect("expected link").is_modified());
         assert!(tree.child(true).is_some());
         assert!(tree.link(false).is_none());
@@ -515,18 +527,16 @@ mod test {
         assert!(tree.link(true).expect("expected link").is_stored());
         assert!(tree.child(true).is_some());
 
-        // tree.link(true).prune(true);
-        // assert!(tree.link(true).expect("expected link").is_pruned());
-        // assert!(tree.child(true).is_none());
-
         let tree = tree.walk(true, |_| None);
         assert!(tree.link(true).is_none());
         assert!(tree.child(true).is_none());
+        Ok(())
     }
 
     #[test]
-    fn child_hash() {
-        let mut tree = Tree::new(vec![0], vec![1]).attach(true, Some(Tree::new(vec![2], vec![3])));
+    fn child_hash() -> Result<()> {
+        let mut tree =
+            Tree::new(vec![0], vec![1])?.attach(true, Some(Tree::new(vec![2], vec![3])?));
         tree.commit(&mut NoopCommit {}).expect("commit failed");
         assert_eq!(
             tree.child_hash(true),
@@ -536,11 +546,12 @@ mod test {
             ]
         );
         assert_eq!(tree.child_hash(false), &NULL_HASH);
+        Ok(())
     }
 
     #[test]
-    fn hash() {
-        let tree = Tree::new(vec![0], vec![1]);
+    fn hash() -> Result<()> {
+        let tree = Tree::new(vec![0], vec![1])?;
         assert_eq!(
             tree.hash(),
             [
@@ -548,28 +559,30 @@ mod test {
                 149, 82, 209, 118, 17, 13, 178, 42, 108, 167, 159, 171, 245, 173
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn child_pending_writes() {
-        let tree = Tree::new(vec![0], vec![1]);
+    fn child_pending_writes() -> Result<()> {
+        let tree = Tree::new(vec![0], vec![1])?;
         assert_eq!(tree.child_pending_writes(true), 0);
         assert_eq!(tree.child_pending_writes(false), 0);
 
-        let tree = tree.attach(true, Some(Tree::new(vec![2], vec![3])));
+        let tree = tree.attach(true, Some(Tree::new(vec![2], vec![3])?));
         assert_eq!(tree.child_pending_writes(true), 1);
         assert_eq!(tree.child_pending_writes(false), 0);
+        Ok(())
     }
 
     #[test]
-    fn height_and_balance() {
-        let tree = Tree::new(vec![0], vec![1]);
+    fn height_and_balance() -> Result<()> {
+        let tree = Tree::new(vec![0], vec![1])?;
         assert_eq!(tree.height(), 1);
         assert_eq!(tree.child_height(true), 0);
         assert_eq!(tree.child_height(false), 0);
         assert_eq!(tree.balance_factor(), 0);
 
-        let tree = tree.attach(true, Some(Tree::new(vec![2], vec![3])));
+        let tree = tree.attach(true, Some(Tree::new(vec![2], vec![3])?));
         assert_eq!(tree.height(), 2);
         assert_eq!(tree.child_height(true), 1);
         assert_eq!(tree.child_height(false), 0);
@@ -581,13 +594,16 @@ mod test {
         assert_eq!(tree.child_height(true), 0);
         assert_eq!(tree.child_height(false), 1);
         assert_eq!(tree.balance_factor(), 1);
+        Ok(())
     }
 
     #[test]
-    fn commit() {
-        let mut tree = Tree::new(vec![0], vec![1]).attach(false, Some(Tree::new(vec![2], vec![3])));
+    fn commit() -> Result<()> {
+        let mut tree =
+            Tree::new(vec![0], vec![1])?.attach(false, Some(Tree::new(vec![2], vec![3])?));
         tree.commit(&mut NoopCommit {}).expect("commit failed");
 
         assert!(tree.link(false).expect("expected link").is_stored());
+        Ok(())
     }
 }


### PR DESCRIPTION
As the title states, this PR addresses two TODOs related to the kv_hash function.  In the first, it changes the behaviour from panicking on a failed range check to returning an error.  It also allows for different hashes to be used with the same function.  This is achieved by changing the function signature from

```
fn kv_hash(key: &[u8], value: &[u8]) -> Hash
```
to
```
fn kv_hash<D: Digest>(key: &[u8], value: &[u8]) -> Result<Hash, TryFromIntError>
```